### PR TITLE
Update env var to VITE_PUBLIC_API_URL for API base URL

### DIFF
--- a/src/lib/placesService.js
+++ b/src/lib/placesService.js
@@ -1,4 +1,4 @@
-const BASE_URL = import.meta.env.VITE_BASE_URL || 'http://localhost:3000';
+const BASE_URL = import.meta.env.VITE_PUBLIC_API_URL || 'http://localhost:3000';
 
 let _cache = null; // array of normalized places
 let _byId = new Map();

--- a/src/page/Home/Home.jsx
+++ b/src/page/Home/Home.jsx
@@ -13,7 +13,7 @@ import "../Plan/css/plan.css";
 
 export default function Home() {
     const navigate = useNavigate();
-    const BASE_URL = import.meta.env.VITE_BASE_URL;
+    const BASE_URL = import.meta.env.VITE_PUBLIC_API_URL;
     const [selectedActivities, setSelectedActivities] = useState(null);
     const [selectedTravel, setSelectedTravel] = useState(null);
     const [destination, setDestination] = useState("");
@@ -202,6 +202,7 @@ export default function Home() {
             }
 
             const base = BASE_URL || 'http://localhost:3000';
+            console.log("Creating plan at:", `${base}/plans`);
             var response = await fetch(`${base}/plans`, {
                 method: 'POST',
                 headers,

--- a/src/page/Plan/Plan.jsx
+++ b/src/page/Plan/Plan.jsx
@@ -7,7 +7,7 @@ import { useLocation, useParams } from "react-router-dom";
 import { PlanMock } from "./mock/Mock.jsx";
 import { getPlaceById, getAllPlacesCached } from "@/lib/placesService";
 import "./plan.css";
-const BASE_URL = import.meta.env.VITE_BASE_URL;
+const BASE_URL = import.meta.env.VITE_PUBLIC_API_URL;
 
 function getToken() {
     // Read jwtToken from cookies (prefer HttpOnly cookie flow; header added only if readable and valid)

--- a/src/page/Plan/component/Field/Field.jsx
+++ b/src/page/Plan/component/Field/Field.jsx
@@ -9,7 +9,7 @@ import { useAutoHideScrollbar } from "@/lib/useAutoHideScrollbar";
 import { href, useNavigate } from "react-router-dom";
 import StartPoint from "./StartPoint";
 
-const BASE_URL = import.meta.env.VITE_BASE_URL;
+const BASE_URL = import.meta.env.VITE_PUBLIC_API_URL;
 
 function getToken() {
     // Read jwtToken from cookies (prefer HttpOnly cookie flow; header added only if readable and valid)


### PR DESCRIPTION
Replaces usage of VITE_BASE_URL with VITE_PUBLIC_API_URL for the API base URL in placesService.js, Home.jsx, Plan.jsx, and Field.jsx. Ensures consistency with environment variable naming and improves configuration clarity.